### PR TITLE
Expose GC, Stats, and Backup/Load

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -29,6 +29,12 @@ type GarbageCollectionOptions struct {
 	DiscardRatio float64
 }
 
+// BadgerStats displays stats about badger
+type BadgerStats struct {
+	LSMSize  int64
+	VLogSize int64
+}
+
 // DefaultGCOptions are the default GarbageCollectionOptions
 var DefaultGCOptions = GarbageCollectionOptions{
 	Frequency:    time.Minute,
@@ -222,4 +228,13 @@ func (c *BadgerCache) Backup(w io.Writer, since uint64) (upto uint64, err error)
 // concurrent transactions while it is running.
 func (c *BadgerCache) Load(r io.Reader) error {
 	return c.db.Load(r)
+}
+
+// Stats provides stats about the Badger database
+func (c *BadgerCache) Stats() BadgerStats {
+	lsm, vlog := c.db.Size()
+	return BadgerStats{
+		LSMSize:  lsm,
+		VLogSize: vlog,
+	}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -247,3 +247,13 @@ func TestLoad(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, b.Bytes(), readB.Bytes())
 }
+
+func TestStats(t *testing.T) {
+	opts := badger.DefaultOptions
+	c, err := NewCache("test-cache-stats", time.Second, &opts, nil)
+	assert.Nil(t, err)
+	defer c.Close()
+
+	s := c.Stats()
+	assert.Equal(t, BadgerStats{0, 0}, s)
+}


### PR DESCRIPTION
- Allow for configuration of garbage collection
- Expose LSM and VLog sizes via stats
- Expose badger backup/load methods